### PR TITLE
default.xml: Enable legacy python2 support

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -6,11 +6,13 @@
   <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>
   <remote fetch="https://github.com/Freescale" name="freescale"/>
   <remote fetch="https://github.com/openembedded" name="oe"/>
+  <remote fetch="https://git.openembedded.org" name="oeorg"/>
 
   <project remote="yocto" revision="master" name="poky" path="sources/poky"/>
   <project remote="yocto" revision="master" name="meta-freescale" path="sources/meta-freescale"/>
 
   <project remote="oe" revision="master" name="meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="oeorg" revision="master" name="meta-python2" path="sources/meta-python2"/>
 
   <project remote="freescale" revision="master" name="fsl-community-bsp-base" path="sources/base">
 	<linkfile dest="README" src="README"/>


### PR DESCRIPTION
Add meta-python2 from openembedded.org to add python2 support, for a while.

Signed-off-by: Cristinel Panfir <cristinel.panfir@nxp.com>