### PR TITLE
Replace git protocol with https

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -3,9 +3,9 @@
 
   <default sync-j="4" revision="daisy"/>
 
-  <remote fetch="git://git.yoctoproject.org" name="yocto"/>
-  <remote fetch="git://github.com/Freescale" name="freescale"/>
-  <remote fetch="git://git.openembedded.org" name="oe"/>
+  <remote fetch="https://git.yoctoproject.org" name="yocto"/>
+  <remote fetch="https://github.com/Freescale" name="freescale"/>
+  <remote fetch="https://git.openembedded.org" name="oe"/>
 
   <project remote="yocto" revision="daisy" name="poky" path="sources/poky"/>
   <project remote="yocto" revision="daisy" name="meta-fsl-arm" path="sources/meta-fsl-arm"/>


### PR DESCRIPTION
Github no longer allows use of git protocol and some users use this
branch.