### PR TITLE
browser.xml: Lock chromium at 98.0.4758.102

### DIFF
--- a/browser.xml
+++ b/browser.xml
@@ -7,6 +7,6 @@
   <remote fetch="https://github.com/OSSystems" name="OSSystems"/>
 
   <project remote="clang" name="meta-clang" path="sources/meta-clang" />
-  <project remote="OSSystems" name="meta-browser" path="sources/meta-browser" />
+  <project remote="OSSystems" name="meta-browser" path="sources/meta-browser" revision="3c81df00f2afbcd646be6aa5346fa16a14d86a6f" />
 
 </manifest>


### PR DESCRIPTION
See https://github.com/Freescale/meta-freescale/pull/1053/files.

The patches in meta-freescale are dependent on the browser version.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
Change-Id: Id08d5e642765f58371aced10aa923dd88fb85367