### PR TITLE
default: Use github to fetch meta-freescale

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -8,7 +8,7 @@
   <remote fetch="https://github.com/openembedded" name="oe"/>
 
   <project remote="yocto" name="poky" path="sources/poky"/>
-  <project remote="yocto" name="meta-freescale" path="sources/meta-freescale"/>
+  <project remote="freescale" name="meta-freescale" path="sources/meta-freescale"/>
 
   <project remote="oe" name="meta-openembedded" path="sources/meta-openembedded"/>
 


### PR DESCRIPTION
Github uses to be faster, so prefer this mirror instead.

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>