### PR TITLE
Deprecate documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,6 +34,9 @@ The source code is checked out at `fsl-community-bsp/sources`.
 
 To contribute to this layer you should send the patches for review to the mailing list.
 
+Preferable Method::
+    Using the GitHub Pull Request created from a fork.
+
 Mailing list::
     https://lists.yoctoproject.org/listinfo/meta-freescale
 

--- a/default.xml
+++ b/default.xml
@@ -19,6 +19,5 @@
 
   <project remote="freescale" name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty"/>
   <project remote="freescale" name="meta-freescale-distro" path="sources/meta-freescale-distro"/>
-  <project remote="freescale" name="Documentation" path="sources/Documentation"/>
 
 </manifest>


### PR DESCRIPTION
Add a note on the preferred way to contribute and deprecate Documentation.

https://github.com/Freescale/Documentation/pull/42