### PR TITLE
default: Update the Yocto Project Repositories

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -3,11 +3,14 @@
 
   <default sync-j="4" revision="master"/>
 
-  <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>
+  <remote fetch="https://git.yoctoproject.org" name="yocto"/>
   <remote fetch="https://github.com/Freescale" name="freescale"/>
   <remote fetch="https://github.com/openembedded" name="oe"/>
 
-  <project remote="yocto" name="poky" path="sources/poky"/>
+  <project remote="oe" name="bitbake" path="sources/bitbake"/>
+  <project remote="oe" name="openembedded-core" path="sources/openembedded-core"/>
+  <project remote="yocto" name="meta-yocto" path="sources/meta-yocto"/>
+  
   <project remote="freescale" name="meta-freescale" path="sources/meta-freescale"/>
 
   <project remote="oe" name="meta-openembedded" path="sources/meta-openembedded"/>


### PR DESCRIPTION
The poky repository master branch is no longer being updated.

https://git.yoctoproject.org/poky/tree/README
7cf111ed1478450bcf82783e36c9a54e8ab3fcae

Change-Id: Id6713169f1b29806f1cbcb3899651b18941decc2

That PR Depends this other PR: https://github.com/Freescale/fsl-community-bsp-base/pull/23